### PR TITLE
✨ Support the credential cache.

### DIFF
--- a/rpc/sasl.go
+++ b/rpc/sasl.go
@@ -2,14 +2,15 @@ package rpc
 
 import (
 	"encoding/binary"
+	"io"
+	"log"
+	"strings"
+
 	hadoop "github.com/colinmarc/hdfs/protocol/hadoop_common"
 	"gopkg.in/jcmturner/gokrb5.v3/client"
 	"gopkg.in/jcmturner/gokrb5.v3/gssapi"
 	"gopkg.in/jcmturner/gokrb5.v3/iana/keyusage"
 	"gopkg.in/jcmturner/gokrb5.v3/types"
-	"io"
-	"log"
-	"strings"
 )
 
 const (


### PR DESCRIPTION
Slight refactor of the config loading for #2 

Also:
 - switched to `goimports -w`instead of `go fmt` as the formatter
 - swtiched to log.Panic instead of log.Fatal (more details for debugging)