### PR TITLE
✨  Formatted JSON output with `ls -j`

### DIFF
--- a/cmd/hdfs/main.go
+++ b/cmd/hdfs/main.go
@@ -29,7 +29,7 @@ var (
 The flags available are a subset of the POSIX ones, but should behave similarly.
 
 Valid commands:
-  ls [-lah] [FILE]...
+  ls [-lahj] [FILE]...
   rm [-rf] FILE...
   mv [-nT] SOURCE... DEST
   mkdir [-p] FILE...
@@ -59,6 +59,7 @@ the following environment variables may be used:
 	lsl    = lsOpts.Bool('l')
 	lsa    = lsOpts.Bool('a')
 	lsh    = lsOpts.Bool('h')
+	lsj    = lsOpts.Bool('j', "Print JSON formatted output")
 
 	rmOpts = getopt.New()
 	rmr    = rmOpts.Bool('r')
@@ -123,7 +124,7 @@ func main() {
 		fatal("gohdfs version", version)
 	case "ls":
 		lsOpts.Parse(argv)
-		ls(lsOpts.Args(), *lsl, *lsa, *lsh)
+		ls(lsOpts.Args(), *lsl, *lsa, *lsh, *lsj)
 	case "rm":
 		rmOpts.Parse(argv)
 		rm(rmOpts.Args(), *rmr, *rmf)


### PR DESCRIPTION
JSON formatted output with the following structure:

```
[
    { "name": "/my/hdfs/file/or/folder1", more attributes },
    { "name": "/my/hdfs/file/or/folder2", more attributes },
    ... more file or folders ...
]
```

Please note that unlike the normal `ls` command `ls -j` always uses absolute path and does ignore the `-h` file size formatting.